### PR TITLE
Fix builds broken by new {core16,18} images

### DIFF
--- a/core16/Dockerfile
+++ b/core16/Dockerfile
@@ -84,12 +84,14 @@ RUN apt-get update && apt-get install -y \
 # as the main point of this image.
 RUN curl -L $(curl -H "X-Ubuntu-Series: 16" "https://api.snapcraft.io/api/v1/snaps/details/core" | jq ".download_url" -r) --output core.snap && \
 	mkdir -p /snap/core && \
-	unsquashfs -d /snap/core/current core.snap
+	unsquashfs -d /snap/core/current core.snap && \
+	rm -f core.snap
 
 # Manually install the snapcraft snap, so we can use it to build new snaps
 RUN curl -L $(curl -H "X-Ubuntu-Series: 16" "https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable" | jq ".download_url" -r) --output snapcraft.snap && \
 	mkdir -p /snap/snapcraft && \
-	unsquashfs -d /snap/snapcraft/current snapcraft.snap
+	unsquashfs -d /snap/snapcraft/current snapcraft.snap && \
+	rm -f snapcraft.snap
 
 # Install the Snapcraft runner
 COPY snapcraft-wrapper /snap/bin/snapcraft

--- a/core18/Dockerfile
+++ b/core18/Dockerfile
@@ -14,17 +14,20 @@ RUN apt-get update && apt-get install -y \
 # Manually install the core snap, a dependency of the snapcraft snap
 RUN curl -L $(curl -H "X-Ubuntu-Series: 16" "https://api.snapcraft.io/api/v1/snaps/details/core" | jq ".download_url" -r) --output core.snap && \
 	mkdir -p /snap/core && \
-	unsquashfs -d /snap/core/current core.snap
+	unsquashfs -d /snap/core/current core.snap && \
+	rm -f core.snap
 
 # Manually install the core18 snap, the main point of this image
 RUN curl -L $(curl -H "X-Ubuntu-Series: 16" "https://api.snapcraft.io/api/v1/snaps/details/core18" | jq ".download_url" -r) --output core18.snap && \
 	mkdir -p /snap/core18 && \
-	unsquashfs -d /snap/core18/current core18.snap
+	unsquashfs -d /snap/core18/current core18.snap && \
+	rm -f core18.snap
 
 # Manually install the snapcraft snap, so we can use it to build new snaps
 RUN curl -L $(curl -H "X-Ubuntu-Series: 16" "https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable" | jq ".download_url" -r) --output snapcraft.snap && \
 	mkdir -p /snap/snapcraft && \
-	unsquashfs -d /snap/snapcraft/current snapcraft.snap
+	unsquashfs -d /snap/snapcraft/current snapcraft.snap && \
+	rm -f snapcraft.snap
 
 # Install the Snapcraft runner
 COPY snapcraft-wrapper /snap/bin/snapcraft


### PR DESCRIPTION
Builds using the new `cibuilds/snapcraft:core18` from PR #11 fail in *Checkout code* phase:
```
Directory (/root/project) you are trying to checkout to is not empty and not a git repository
```
Inspecting the build machine with SSH, there are indeed unwanted files in there that don't come from some cache, as I initially assumed, but are artifacts of building the docker images:
```
$ ls -lh /root/project
total 201M
-rw-r--r-- 1 root root 55M Oct 14 10:10 core18.snap
-rw-r--r-- 1 root root 90M Oct 14 10:10 core.snap
-rw-r--r-- 1 root root 58M Oct 14 10:10 snapcraft.snap
$
```

Reviewing the new Dockerfiles, they don't clean the downloaded snap files. I'm not entirely sure why CWD is `/root/project` (`WORKDIR` is supposed to take effect for subsequent commands…), but that's apparently where the files do end up, and it's good to remove the leftovers even if they didn't break the build.

This PR deletes the squashfs images after unpacking them.