### PR TITLE
Pull Snapcraft v3.9.x

### DIFF
--- a/core16/Dockerfile
+++ b/core16/Dockerfile
@@ -112,4 +112,4 @@ WORKDIR /root/project
 # a majority of snaps. This increases build times which isn't good in CI.
 # The echo statement allows us to break the cache for this step more easily 
 # while also providing context.
-RUN apt-get update && echo "Apt index last updated October 13, 2019 at the earliest."
+RUN apt-get update && echo "Apt index last updated January 12, 2020 at the earliest."

--- a/core18/Dockerfile
+++ b/core18/Dockerfile
@@ -1,7 +1,7 @@
 # vim:set ft=dockerfile:
 
 # Ubuntu 18.04 based image to match the core18 snap
-FROM cimg/base:2019.10
+FROM cimg/base:2019.11
 
 LABEL maintainer="Ricardo N Feliciano (FelicianoTech) <Ricardo@Feliciano.Tech>"
 
@@ -48,4 +48,4 @@ WORKDIR /root/project
 # a majority of snaps. This increases build times which isn't good in CI.
 # The echo statement allows us to break the cache for this step more easily 
 # while also providing context.
-RUN apt-get update && echo "Apt index last updated October 13, 2019 at the earliest."
+RUN apt-get update && echo "Apt index last updated January 12, 2020 at the earliest."


### PR DESCRIPTION
This PR is mostly to pull a newer version of Snapcraft. At the same
thime though, we're updating the base image for core18 to the CircleCI
November base. We're not switching to the January base yet as there's
more work and communication I need to do around not defaulting to the
root user anymore.